### PR TITLE
This one line fix will make your head spin

### DIFF
--- a/kitchen-digital_ocean.gemspec
+++ b/kitchen-digital_ocean.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'test-kitchen', '~> 1.0'
-  spec.add_dependency 'rest_client'
+  spec.add_dependency 'rest-client', '~> 1.7'
 
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
rest_client includes an old version of rest-client. Recent versions of rest-client no longer use SSLv3 by default.
